### PR TITLE
Shorten the cache TTL by 5 seconds and specify that the cache uses se…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ module.exports.setLogger(altLogger);
 ```
 Note that the alternative caching method you use must return promises and have the following function definitions:
 * get(key)
-* set(key, value, ttl)
+* set(key, value, ttl-in-seconds)
 
 #### Events for Requests/Responses
 

--- a/src/auth0V2.js
+++ b/src/auth0V2.js
@@ -22,7 +22,7 @@ const retrieveV2TokenFromCache = (config, audience) => {
 const saveV2TokenInCache = (config, audience, token) => {
   const cacheKey = generateAuthV2TokenCacheKey(config, audience);
   const decodedToken = jwt.decode(token);
-  return cache.set(cacheKey, token, decodedToken.exp - decodedToken.iat)
+  return cache.set(cacheKey, token, decodedToken.exp - decodedToken.iat - 5)
     .catch((error) => {
       logger(`Error saving v2 token ${cacheKey} in cache: ${JSON.stringify(error)}`);
     });


### PR DESCRIPTION
…conds in the readme

We've had our jwt token be expired and I think this can practically eradicate this situation.